### PR TITLE
tinyci-relay: need to import sys

### DIFF
--- a/firmware/tinyci-fw/tinyci-relay.py
+++ b/firmware/tinyci-fw/tinyci-relay.py
@@ -8,7 +8,7 @@
 # -*- coding: utf-8 -*-
 
 import socket
-
+import sys
 
 # -----------  Config  ----------
 PORT = 1234


### PR DESCRIPTION
My cleaning via f256e9216f3e ("firmware: tinyci-relay: remove unused import") was too much, I removed sys when I should not.

Signed-off-by: Corentin LABBE <clabbe.montjoie@gmail.com>